### PR TITLE
Make content title in SequentialOnboardingView optional

### DIFF
--- a/Sources/SpeziOnboarding/SequentialOnboardingView.swift
+++ b/Sources/SpeziOnboarding/SequentialOnboardingView.swift
@@ -51,10 +51,20 @@ public struct SequentialOnboardingView: View {
         ///   - title: The title of the area in the ``SequentialOnboardingView``.
         ///   - description: The description of the area in the ``SequentialOnboardingView``.
         public init<Title: StringProtocol, Description: StringProtocol>(
-            title: Title?,
+            title: Title,
             description: Description
         ) {
-            self.title = title?.localized
+            self.title = title.localized
+            self.description = description.localized
+        }
+
+        /// Creates a new content for an area in the ``SequentialOnboardingView``.
+        /// - Parameters:
+        ///   - description: The description of the area in the ``SequentialOnboardingView``.
+        public init<Description: StringProtocol>(
+            description: Description
+        ) {
+            self.title = nil
             self.description = description.localized
         }
     }

--- a/Sources/SpeziOnboarding/SequentialOnboardingView.swift
+++ b/Sources/SpeziOnboarding/SequentialOnboardingView.swift
@@ -41,7 +41,7 @@ public struct SequentialOnboardingView: View {
     /// A ``Content`` defines the way that information is displayed in an ``SequentialOnboardingView``.
     public struct Content {
         /// The title of the area in the ``SequentialOnboardingView``.
-        public let title: String
+        public let title: String?
         /// The description of the area in the ``SequentialOnboardingView``.
         public let description: String
         
@@ -51,10 +51,10 @@ public struct SequentialOnboardingView: View {
         ///   - title: The title of the area in the ``SequentialOnboardingView``.
         ///   - description: The description of the area in the ``SequentialOnboardingView``.
         public init<Title: StringProtocol, Description: StringProtocol>(
-            title: Title,
+            title: Title?,
             description: Description
         ) {
-            self.title = title.localized
+            self.title = title?.localized
             self.description = description.localized
         }
     }
@@ -166,8 +166,10 @@ public struct SequentialOnboardingView: View {
                             .fill(Color.accentColor)
                     }
                 VStack(alignment: .leading, spacing: 8) {
-                    Text(content.title)
-                        .bold()
+                    if let title = content.title {
+                        Text(title)
+                            .bold()
+                    }
                     Text(content.description)
                 }
                 Spacer()

--- a/Tests/UITests/TestApp/OnboardingTestsView.swift
+++ b/Tests/UITests/TestApp/OnboardingTestsView.swift
@@ -109,9 +109,9 @@ struct OnboardingTestsView: View {
             title: "Things to know",
             subtitle: "And you should pay close attention ...",
             content: [
-                .init(title: "A thing to know", description: "This is a first thing that you should know, read carfully!"),
-                .init(title: "Second thing to know", description: "This is a second thing that you should know, read carfully!"),
-                .init(title: "Third thing to know", description: "This is a third thing that you should know, read carfully!")
+                .init(title: "A thing to know", description: "This is a first thing that you should know, read carefully!"),
+                .init(title: "Second thing to know", description: "This is a second thing that you should know, read carefully!"),
+                .init(title: "Third thing to know", description: "This is a third thing that you should know, read carefully!"),
             ],
             actionText: "Continue"
         ) {

--- a/Tests/UITests/TestApp/OnboardingTestsView.swift
+++ b/Tests/UITests/TestApp/OnboardingTestsView.swift
@@ -112,6 +112,7 @@ struct OnboardingTestsView: View {
                 .init(title: "A thing to know", description: "This is a first thing that you should know, read carefully!"),
                 .init(title: "Second thing to know", description: "This is a second thing that you should know, read carefully!"),
                 .init(title: "Third thing to know", description: "This is a third thing that you should know, read carefully!"),
+                .init(description: "Now you should know all the things!")
             ],
             actionText: "Continue"
         ) {

--- a/Tests/UITests/TestAppUITests/SpeziOnboardingTests.swift
+++ b/Tests/UITests/TestAppUITests/SpeziOnboardingTests.swift
@@ -95,7 +95,7 @@ final class OnboardingTests: XCTestCase {
         XCTAssert(app.staticTexts["And you should pay close attention ..."].exists)
     }
     
-    func testSequencialOnboarding() throws {
+    func testSequentialOnboarding() throws {
         let app = XCUIApplication()
         app.launch()
         
@@ -118,6 +118,9 @@ final class OnboardingTests: XCTestCase {
         app.buttons["Next"].tap()
         XCTAssert(app.staticTexts["3"].exists)
         XCTAssert(app.staticTexts["Third thing to know"].exists)
+
+        app.buttons["Next"].tap()
+        XCTAssert(app.staticTexts["Now you should know all the things!"].exists)
         
         XCTAssert(app.staticTexts["1"].exists)
         XCTAssert(app.staticTexts["A thing to know"].exists)
@@ -125,7 +128,6 @@ final class OnboardingTests: XCTestCase {
         XCTAssert(app.staticTexts["Second thing to know"].exists)
         XCTAssert(app.staticTexts["3"].exists)
         XCTAssert(app.staticTexts["Third thing to know"].exists)
-        XCTAssert(app.staticTexts["Now you should know all the things!"].exists)
         app.buttons["Continue"].tap()
         
         XCTAssert(app.staticTexts["Consent"].exists)

--- a/Tests/UITests/TestAppUITests/SpeziOnboardingTests.swift
+++ b/Tests/UITests/TestAppUITests/SpeziOnboardingTests.swift
@@ -125,6 +125,7 @@ final class OnboardingTests: XCTestCase {
         XCTAssert(app.staticTexts["Second thing to know"].exists)
         XCTAssert(app.staticTexts["3"].exists)
         XCTAssert(app.staticTexts["Third thing to know"].exists)
+        XCTAssert(app.staticTexts["Now you should know all the things!"].exists)
         app.buttons["Continue"].tap()
         
         XCTAssert(app.staticTexts["Consent"].exists)


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Make content title in SequentialOnboardingView optional

## :recycle: Current situation & Problem
A title is currently required for each content section in SequentialOnboardingView. However, there are situations in which a title is not needed or useful. Examples include the `LLMonFHIR` and `HealthGPT` onboarding where the same title is repeated in each section. Passing an empty string for the title leaves a space, which is not desirable.

## :bulb: Proposed solution
Adds a new initializer that takes only a description, if a title isn't necessary for the section.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
