### PR TITLE
Enable async action closure in ConsentView

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,8 +10,6 @@
 only_rules:
   # All Images that provide context should have an accessibility label. Purely decorative images can be hidden from accessibility.
   - accessibility_label_for_image
-  # Attributes should be on their own lines in functions and types, but on the same line as variables and imports.
-  - attributes
   # Prefer using Array(seq) over seq.map { $0 } to convert a sequence into an Array.
   - array_init
   # Prefer the new block based KVO API with keypaths when using Swift 3.2 or later.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,7 +4,7 @@
 # SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #
 # SPDX-License-Identifier: MIT
-# 
+#
 
 # The whitelist_rules configuration also includes rules that are enabled by default to provide a good overview of all rules.
 only_rules:

--- a/Sources/SpeziOnboarding/ConsentView.swift
+++ b/Sources/SpeziOnboarding/ConsentView.swift
@@ -112,7 +112,7 @@ public struct ConsentView<ContentView: View, Action: View>: View {
         @ViewBuilder header: () -> (some View) = { EmptyView() },
         asyncMarkdown: @escaping () async -> Data,
         @ViewBuilder footer: () -> (some View) = { EmptyView() },
-        action: @escaping () -> Void,
+        action: @escaping () async -> Void,
         givenNameField: FieldLocalization = LocalizationDefaults.givenName,
         familyNameField: FieldLocalization = LocalizationDefaults.familyName
     ) where ContentView == AnyView, Action == OnboardingActionsView {
@@ -131,7 +131,7 @@ public struct ConsentView<ContentView: View, Action: View>: View {
             },
             actionView: {
                 OnboardingActionsView(String(localized: "CONSENT_ACTION", bundle: .module)) {
-                    action()
+                    await action()
                 }
             },
             givenNameField: givenNameField,
@@ -149,7 +149,7 @@ public struct ConsentView<ContentView: View, Action: View>: View {
         @ViewBuilder header: () -> (some View) = { EmptyView() },
         asyncHTML: @escaping () async -> Data,
         @ViewBuilder footer: () -> (some View) = { EmptyView() },
-        action: @escaping () -> Void,
+        action: @escaping () async -> Void,
         givenNameField: FieldLocalization = LocalizationDefaults.givenName,
         familyNameField: FieldLocalization = LocalizationDefaults.familyName
     ) where ContentView == AnyView, Action == OnboardingActionsView {
@@ -168,7 +168,7 @@ public struct ConsentView<ContentView: View, Action: View>: View {
             },
             actionView: {
                 OnboardingActionsView(String(localized: "CONSENT_ACTION", bundle: .module)) {
-                    action()
+                    await action()
                 }
             },
             givenNameField: givenNameField,

--- a/Sources/SpeziOnboarding/SignatureView.swift
+++ b/Sources/SpeziOnboarding/SignatureView.swift
@@ -26,7 +26,7 @@ import SwiftUI
 /// )
 /// ```
 public struct SignatureView: View {
-    @Environment(\.undoManager) private var undoManager
+    @Environment(\.undoManager) private var undoManager // swiftlint:disable:this attributes
     @Binding private var signature: PKDrawing
     @Binding private var isSigning: Bool
     @State private var canUndo = false

--- a/Sources/SpeziOnboarding/SignatureView.swift
+++ b/Sources/SpeziOnboarding/SignatureView.swift
@@ -26,7 +26,7 @@ import SwiftUI
 /// )
 /// ```
 public struct SignatureView: View {
-    @Environment(\.undoManager) private var undoManager // swiftlint:disable:this attributes
+    @Environment(\.undoManager) private var undoManager
     @Binding private var signature: PKDrawing
     @Binding private var isSigning: Bool
     @State private var canUndo = false

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -617,7 +617,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/XCTestExtensions";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.1;
+				minimumVersion = 0.4.6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Async action within OnboardingActionsView

## :recycle: Current situation & Problem
The `ConsentView` takes an action closure that is synchronous in nature. This closure is passed to the `OnboardingActionsView` which also takes an asynchronous function.

## :bulb: Proposed solution
Enable passing an asynchronous function to the `ConsentView`.
This enables the following code block:
```swift
ConsentView(
    header: ...,
    asyncMarkdown: ...,
    action: {
        await testFunction()
    }
)
```

## :gear: Release Notes 
- `ConsentView` action parameter takes an asynchronous closure

## :heavy_plus_sign: Additional Information
--

### Related PRs
[SpeziTemplateApplication PR](https://github.com/StanfordSpezi/SpeziTemplateApplication/pull/26)

### Testing
--

### Reviewer Nudging
Very minor code changes

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
