### PR TITLE
Remove Async Operations in `OnboardingNavigationPath`

### DIFF
--- a/Sources/SpeziOnboarding/OnboardingFlow/OnboardingNavigationPath.swift
+++ b/Sources/SpeziOnboarding/OnboardingFlow/OnboardingNavigationPath.swift
@@ -157,9 +157,7 @@ public class OnboardingNavigationPath: ObservableObject {
     
     /// Removes the last element on top of the internal `NavigationPath` of the ``OnboardingNavigationPath``, meaning one is able to manually move backwards within the onboarding navigation flow.
     public func removeLast() {
-        Task {
-            path.removeLast()
-        }
+        path.removeLast()
     }
     
     /// Internal function used to update the onboarding steps within the ``OnboardingNavigationPath`` if the result builder associated with the ``OnboardingStack`` is reevaluated. This may be the case with `async` properties that are stored as a SwiftUI `State` in the respective view.
@@ -210,16 +208,12 @@ public class OnboardingNavigationPath: ObservableObject {
     }
     
     private func appendToInternalNavigationPath(of onboardingStepIdentifier: OnboardingStepIdentifier) {
-        Task {
-            path.append(onboardingStepIdentifier)
-        }
+        path.append(onboardingStepIdentifier)
     }
     
     private func onboardingComplete() {
-        Task {
-            if self.onboardingSteps.isEmpty && !(self.complete?.wrappedValue ?? false) {
-                self.complete?.wrappedValue = true
-            }
+        if self.onboardingSteps.isEmpty && !(self.complete?.wrappedValue ?? false) {
+            self.complete?.wrappedValue = true
         }
     }
 }

--- a/Tests/UITests/TestApp/Views/OnboardingWelcomeTestView.swift
+++ b/Tests/UITests/TestApp/Views/OnboardingWelcomeTestView.swift
@@ -11,6 +11,7 @@ import SpeziViews
 import SwiftUI
 
 
+// swiftlint:disable:accessibility_label_for_image
 struct OnboardingWelcomeTestView: View {
     @EnvironmentObject private var path: OnboardingNavigationPath
     

--- a/Tests/UITests/TestApp/Views/OnboardingWelcomeTestView.swift
+++ b/Tests/UITests/TestApp/Views/OnboardingWelcomeTestView.swift
@@ -11,7 +11,7 @@ import SpeziViews
 import SwiftUI
 
 
-// swiftlint:disable:accessibility_label_for_image
+// swiftlint:disable accessibility_label_for_image
 struct OnboardingWelcomeTestView: View {
     @EnvironmentObject private var path: OnboardingNavigationPath
     


### PR DESCRIPTION
# Remove Async Operations in `OnboardingNavigationPath`

## :recycle: Current situation & Problem
- A few operations in the `OnboardingNavigationPath` type did not use any concurrency-related features.


## :gear: Release Notes 
- Removes async operations in the `OnboardingNavigationPath` type that did not use any concurrency-related features.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
