### PR TITLE
UI Test for consent form export

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,18 +19,34 @@ jobs:
   buildandtest:
     name: Build and Test Swift Package
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    strategy:
+      matrix:
+        include:
+          - buildConfig: Debug
+            artifactname: SpeziOnboarding.xcresult
+          - buildConfig: Release
+            artifactname: SpeziOnboarding-Release.xcresult
     with:
-      artifactname: SpeziOnboarding.xcresult
+      artifactname: ${{ matrix.artifactname }}
       runsonlabels: '["macOS", "self-hosted"]'
       scheme: SpeziOnboarding
+      buildConfig: ${{ matrix.buildConfig }}
   buildandtestuitests:
     name: Build and Test UI Tests
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    strategy:
+      matrix:
+        include:
+          - buildConfig: Debug
+            artifactname: TestApp.xcresult
+          - buildConfig: Release
+            artifactname: TestApp-Release.xcresult
     with:
-      artifactname: TestApp.xcresult
+      artifactname: ${{ matrix.artifactname }}
       runsonlabels: '["macOS", "self-hosted"]'
       path: 'Tests/UITests'
       scheme: TestApp
+      buildConfig: ${{ matrix.buildConfig }}
   uploadcoveragereport:
     name: Upload Coverage Report
     needs: [buildandtest, buildandtestuitests]


### PR DESCRIPTION
# UI Test for consent form export

## :recycle: Current situation & Problem
Currently, the consent form export is only tested by storing the PDF via the Standard to the app caches directory. The test only validates that the file actually exists, but doesn't check the content. Also, the functionality of the share sheet is not tested.
Also, the package is only building and testing for Debug mode right now.

## :gear: Release Notes 
- UI Test for consent form export
- Build and test the package as well as the UI tests in Debug and Release mode


## :books: Documentation
Proper documentation of the test behavior


## :white_check_mark: Testing
This PR only contains a UI test ;)


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
