### PR TITLE
Content adjustment for upcoming onboarding steps

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -137,3 +137,5 @@ jobs:
     uses: StanfordSpezi/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
     with:
       coveragereports: 'SpeziOnboarding-iOS.xcresult SpeziOnboarding-visionOS.xcresult SpeziOnboarding-macOS.xcresult TestApp-iOS.xcresult TestApp-iPad.xcresult TestApp-visionOS.xcresult'
+    secrets:
+      token: ${{ secrets.CODECOV_TOKEN }}

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.2.1"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.3.1")
+        .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.3.1"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0")
     ],
     targets: [
         .target(
@@ -32,7 +33,8 @@ let package = Package(
             dependencies: [
                 .product(name: "Spezi", package: "Spezi"),
                 .product(name: "SpeziViews", package: "SpeziViews"),
-                .product(name: "SpeziPersonalInfo", package: "SpeziViews")
+                .product(name: "SpeziPersonalInfo", package: "SpeziViews"),
+                .product(name: "OrderedCollections", package: "swift-collections")
             ]
         ),
         .testTarget(

--- a/Sources/SpeziOnboarding/OnboardingFlow/OnboardingNavigationPath.swift
+++ b/Sources/SpeziOnboarding/OnboardingFlow/OnboardingNavigationPath.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import OrderedCollections
 import SwiftUI
 
 
@@ -54,15 +55,23 @@ public class OnboardingNavigationPath {
     /// Indicates if the onboarding flow is completed, meaning the last view declared within the ``OnboardingStack`` is completed.
     private let complete: Binding<Bool>?
 
-    /// Stores all onboarding views as declared within the ``OnboardingStack``.
-    private var onboardingSteps: [OnboardingStepIdentifier: any View] = [:]
+    /// Stores all onboarding views as declared within the ``OnboardingStack`` and keep them in order.
+    private var onboardingSteps: OrderedDictionary<OnboardingStepIdentifier, any View> = [:]
     /// Stores all custom onboarding views that are appended to the `OnboardingNavigationPath`
     /// via the ``append(customView:)`` or ``append(customViewInit:)`` instance methods
     private var customOnboardingSteps: [OnboardingStepIdentifier: any View] = [:]
-    /// Stores all `OnboardingStepIdentifier`s in-order as declared by the onboarding views within the ``OnboardingStack``.
-    private var onboardingStepsOrder: [OnboardingStepIdentifier] = []
+
     
-    
+    /// ``OnboardingStepIdentifier`` of first view in ``OnboardingStack``.
+    /// `nil` if ``OnboardingStack`` is empty.
+    private var firstOnboardingStepIdentifier: OnboardingStepIdentifier? {
+        if onboardingSteps.elements.isEmpty {
+            return nil
+        } else {
+            return onboardingSteps.elements[0].key
+        }
+    }
+
     /// The initial view that is presented to the user.
     ///
     /// The first onboarding view of the `OnboardingNavigationPath.onboardingSteps`.
@@ -72,7 +81,7 @@ public class OnboardingNavigationPath {
     /// the property serves an `EmptyView` which is then dismissed immediately as the `OnboardingNavigationPath.complete` property
     /// is automatically set to true.
     var firstOnboardingView: AnyView {
-        guard let firstOnboardingStepIdentifier = onboardingStepsOrder.first,
+        guard let firstOnboardingStepIdentifier,
               let view = onboardingSteps[firstOnboardingStepIdentifier] else {
             return .init(EmptyView())
         }
@@ -89,12 +98,11 @@ public class OnboardingNavigationPath {
     /// of the first onboarding view.
     private var currentOnboardingStep: OnboardingStepIdentifier? {
         guard let lastElement = path.last(where: { !$0.custom }) else {
-            return onboardingStepsOrder.first
+            return firstOnboardingStepIdentifier
         }
         
         return lastElement
     }
-    
     
     /// An `OnboardingNavigationPath` represents the current navigation path within the ``OnboardingStack``.
     /// - Parameters:
@@ -122,14 +130,14 @@ public class OnboardingNavigationPath {
     ///
     /// After all onboarding steps have been shown, the injected `complete` `Binding` is set to true indicating that the onboarding flow is completed.
     public func nextStep() {
-        guard let currentStepIndex = onboardingStepsOrder.firstIndex(where: { $0 == currentOnboardingStep }),
-              currentStepIndex + 1 < onboardingStepsOrder.count else {
+        guard let currentStepIndex = onboardingSteps.elements.keys.firstIndex(where: { $0 == currentOnboardingStep }),
+              currentStepIndex + 1 < onboardingSteps.elements.count else {
             complete?.wrappedValue = true
             return
         }
         
         appendToInternalNavigationPath(
-            of: onboardingStepsOrder[currentStepIndex + 1]
+            of: onboardingSteps.elements.keys[currentStepIndex + 1]
         )
     }
     
@@ -188,21 +196,20 @@ public class OnboardingNavigationPath {
         // Without this limitation, attempts to navigate backwards or dismiss the currently displayed onboarding step
         // (for example, after receiving HealthKit authorizations) could lead to unintended behavior.
         let currentStepIndex = if let currentOnboardingStep {
-            onboardingStepsOrder.firstIndex(of: currentOnboardingStep) ?? 0
+            onboardingSteps.elements.keys.firstIndex(of: currentOnboardingStep) ?? 0
         } else {
             0
         }
 
         // Remove all onboarding steps after the current onboarding step
         let nextStepIndex = currentStepIndex + 1
-        if nextStepIndex < onboardingStepsOrder.count {
-            self.onboardingStepsOrder.removeSubrange(nextStepIndex...)
-            self.onboardingSteps = onboardingSteps.filter { onboardingStepsOrder.contains($0.key) }
+        if nextStepIndex < onboardingSteps.elements.count {
+            self.onboardingSteps.removeSubrange(nextStepIndex...)
         }
 
         for view in views {
             let onboardingStepIdentifier = OnboardingStepIdentifier(fromView: view)
-            let stepIsAfterCurrentStep = !self.onboardingStepsOrder.contains(onboardingStepIdentifier)
+            let stepIsAfterCurrentStep = !self.onboardingSteps.keys.contains(onboardingStepIdentifier)
             guard stepIsAfterCurrentStep else {
                 continue
             }
@@ -214,7 +221,6 @@ public class OnboardingNavigationPath {
                     """)
             }
 
-            self.onboardingStepsOrder.append(onboardingStepIdentifier)
             self.onboardingSteps[onboardingStepIdentifier] = view
         }
         onboardingComplete()

--- a/Tests/UITests/TestApp/OnboardingTestsView.swift
+++ b/Tests/UITests/TestApp/OnboardingTestsView.swift
@@ -25,7 +25,8 @@ struct OnboardingTestsView: View {
             OnboardingSequentialTestView()
             OnboardingConsentMarkdownTestView()
             OnboardingConsentMarkdownRenderingView()
-            
+            OnboardingCustomToggleTestView(showConditionalView: $showConditionalView)
+
             if showConditionalView {
                 OnboardingConditionalTestView()
             }

--- a/Tests/UITests/TestApp/Views/OnboardingCustomToggleTestView.swift
+++ b/Tests/UITests/TestApp/Views/OnboardingCustomToggleTestView.swift
@@ -1,0 +1,29 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SpeziOnboarding
+import SwiftUI
+
+struct OnboardingCustomToggleTestView: View {
+    @Environment(OnboardingNavigationPath.self) private var path
+    @Binding var showConditionalView: Bool
+
+    var body: some View {
+        Button {
+            path.nextStep()
+        } label: {
+            Text("Next")
+        }
+
+        /// We need to use a custom-built toggle as UI tests are very flakey when clicking on SwiftUI `Toggle`'s
+        CustomToggleView(
+            text: "Show Conditional View",
+            condition: $showConditionalView
+        )
+    }
+}

--- a/Tests/UITests/TestApp/Views/OnboardingStartTestView.swift
+++ b/Tests/UITests/TestApp/Views/OnboardingStartTestView.swift
@@ -41,7 +41,7 @@ struct OnboardingStartTestView: View {
             } label: {
                 Text("Rendered Consent View (Markdown)")
             }
-            
+
             Button {
                 path.append(
                     customView: OnboardingCustomTestView1(exampleArgument: "Hello Spezi!")

--- a/Tests/UITests/TestAppUITests/SpeziOnboardingTests.swift
+++ b/Tests/UITests/TestAppUITests/SpeziOnboardingTests.swift
@@ -72,7 +72,10 @@ final class OnboardingTests: XCTestCase { // swiftlint:disable:this type_body_le
         
         XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
         app.buttons["Next"].tap()
-        
+
+        XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
+        app.buttons["Next"].tap()
+
         // Check if on final page
         XCTAssert(app.staticTexts["Onboarding complete"].waitForExistence(timeout: 2))
     }
@@ -386,7 +389,36 @@ final class OnboardingTests: XCTestCase { // swiftlint:disable:this type_body_le
         
         try dynamicOnboardingFlow(app: app, showConditionalView: true)
     }
-    
+
+    func testDynamicOnboardingFlow3() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        XCTAssert(app.buttons["Rendered Consent View (Markdown)"].waitForExistence(timeout: 2))
+        app.buttons["Rendered Consent View (Markdown)"].tap()
+
+        // Check if on consent export page
+        XCTAssert(app.staticTexts["Consent PDF rendering doesn't exist"].waitForExistence(timeout: 2))
+
+        XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
+        app.buttons["Next"].tap()
+
+        XCTAssert(app.buttons["Show Conditional View"].waitForExistence(timeout: 2))
+        app.buttons["Show Conditional View"].tap()
+
+        XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
+        app.buttons["Next"].tap()
+
+        // Check if on conditional test view
+        XCTAssert(app.staticTexts["Conditional Test View"].waitForExistence(timeout: 2))
+
+        XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
+        app.buttons["Next"].tap()
+
+        // Check if on final page
+        XCTAssert(app.staticTexts["Onboarding complete"].waitForExistence(timeout: 2))
+    }
+
     private func hitConsentButton(_ app: XCUIApplication) {
         if app.staticTexts["This is a markdown example"].isHittable {
             app.staticTexts["This is a markdown example"].swipeUp()
@@ -412,7 +444,10 @@ final class OnboardingTests: XCTestCase { // swiftlint:disable:this type_body_le
         
         XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
         app.buttons["Next"].tap()
-        
+
+        XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
+        app.buttons["Next"].tap()
+
         if showConditionalView {
             // Check if on conditional test view
             XCTAssert(app.staticTexts["Conditional Test View"].waitForExistence(timeout: 2))

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2F61BDCB29DDE76D00D71D33 /* SpeziOnboardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F61BDCA29DDE76D00D71D33 /* SpeziOnboardingTests.swift */; };
 		2F6D139A28F5F386007C25D6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2F6D139928F5F386007C25D6 /* Assets.xcassets */; };
 		2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA7382B290ADFAA007ACEB9 /* TestApp.swift */; };
+		61D77B542BC83F0100E3165F /* OnboardingCustomToggleTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D77B532BC83F0100E3165F /* OnboardingCustomToggleTestView.swift */; };
 		970D444B2A6F031200756FE2 /* OnboardingConsentMarkdownTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970D444A2A6F031200756FE2 /* OnboardingConsentMarkdownTestView.swift */; };
 		970D444F2A6F048A00756FE2 /* OnboardingWelcomeTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970D444E2A6F048A00756FE2 /* OnboardingWelcomeTestView.swift */; };
 		970D44512A6F04ED00756FE2 /* OnboardingSequentialTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970D44502A6F04ED00756FE2 /* OnboardingSequentialTestView.swift */; };
@@ -46,6 +47,7 @@
 		2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2FA7382B290ADFAA007ACEB9 /* TestApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
 		2FB0758A299DDB9000C0B37F /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestApp.xctestplan; sourceTree = "<group>"; };
+		61D77B532BC83F0100E3165F /* OnboardingCustomToggleTestView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingCustomToggleTestView.swift; sourceTree = "<group>"; };
 		970D444A2A6F031200756FE2 /* OnboardingConsentMarkdownTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingConsentMarkdownTestView.swift; sourceTree = "<group>"; };
 		970D444E2A6F048A00756FE2 /* OnboardingWelcomeTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWelcomeTestView.swift; sourceTree = "<group>"; };
 		970D44502A6F04ED00756FE2 /* OnboardingSequentialTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSequentialTestView.swift; sourceTree = "<group>"; };
@@ -132,6 +134,7 @@
 		970D44472A6F02E800756FE2 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				61D77B532BC83F0100E3165F /* OnboardingCustomToggleTestView.swift */,
 				97A8FF2F2A74606A008CD91A /* HelperViews */,
 				970D44522A6F0B1900756FE2 /* OnboardingStartTestView.swift */,
 				970D444E2A6F048A00756FE2 /* OnboardingWelcomeTestView.swift */,
@@ -290,6 +293,7 @@
 				97C6AF772ACC86B70060155B /* ExampleStandard.swift in Sources */,
 				970D44532A6F0B1900756FE2 /* OnboardingStartTestView.swift in Sources */,
 				970D44512A6F04ED00756FE2 /* OnboardingSequentialTestView.swift in Sources */,
+				61D77B542BC83F0100E3165F /* OnboardingCustomToggleTestView.swift in Sources */,
 				97A8FF2C2A74449F008CD91A /* OnboardingCustomTestView1.swift in Sources */,
 				2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */,
 				97A8FF2E2A7444FC008CD91A /* OnboardingCustomTestView2.swift in Sources */,


### PR DESCRIPTION
# Content adjustment for upcoming onboarding steps

## :recycle: Current situation & Problem

Closes #44.
`OnboardingStack` only allowed modifications to its views (i.e. order and content of the `OnboardingStack`) when the onboarding process was at its first step (i.e. no navigation operations have occurred). We want to loosen this restriction by allowing modifications to all views that are ahead of the current onboarding step.


## :gear: Release Notes 

* `OnboardingNavigationPath.updateViews`: update all views that are ahead of current onboarding step instead of only updating views on the first onboarding step

## :books: Documentation

* _No changes to public interface_

## :white_check_mark: Testing

- [x] Create UI Test

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
