### PR TITLE
Be less restrictive about the chosen swiftlint version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,7 +74,7 @@ func swiftLintPlugin() -> [Target.PluginUsage] {
 
 func swiftLintPackage() -> [PackageDescription.Package.Dependency] {
     if ProcessInfo.processInfo.environment["SPEZI_DEVELOPMENT_SWIFTLINT"] != nil {
-        [.package(url: "https://github.com/realm/SwiftLint.git", .upToNextMinor(from: "0.55.1"))]
+        [.package(url: "https://github.com/realm/SwiftLint.git", from: "0.55.1")]
     } else {
         []
     }

--- a/Sources/SpeziOnboarding/ConsentView/ConsentDocument.swift
+++ b/Sources/SpeziOnboarding/ConsentView/ConsentDocument.swift
@@ -108,7 +108,7 @@ public struct ConsentDocument: View {
         }
     }
     
-    private var signatureView: some View {
+    @MainActor private var signatureView: some View {
         Group {
             #if !os(macOS)
             SignatureView(signature: $signature, isSigning: $viewState.signing, canvasSize: $signatureSize, name: name)

--- a/Sources/SpeziOnboarding/ConsentView/ConsentViewState+Binding.swift
+++ b/Sources/SpeziOnboarding/ConsentView/ConsentViewState+Binding.swift
@@ -13,7 +13,7 @@ import SwiftUI
 /// Extension to SwiftUI `Binding`'s enabling easy access to individual states of the ``ConsentViewState``
 extension Binding where Value == ConsentViewState {
     /// Access to a `Binding` of the ``ConsentViewState/base(_:)`` view state
-    var base: Binding<SpeziViews.ViewState> {
+    @MainActor var base: Binding<SpeziViews.ViewState> {
         .init(
             get: {
                 if case let .base(value) = self.wrappedValue {
@@ -30,7 +30,7 @@ extension Binding where Value == ConsentViewState {
     }
     
     /// Access to a `Binding` of the ``ConsentViewState/signing`` view state
-    var signing: Binding<Bool> {
+    @MainActor var signing: Binding<Bool> {
         .init(
             get: {
                 if case .signing = self.wrappedValue {


### PR DESCRIPTION
# Be less restrictive about the chosen swiftlint version

## :recycle: Current situation & Problem
This PR loosens the restrictions on the swiftlint version.


## :gear: Release Notes 
* Allow upToNextMajor swiftlint versions.
* Fixed a small concurrency issue.


## :books: Documentation
--


## :white_check_mark: Testing
--

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
