### PR TITLE
padding adjustment

### DIFF
--- a/Sources/SpeziOnboarding/OnboardingView.swift
+++ b/Sources/SpeziOnboarding/OnboardingView.swift
@@ -77,6 +77,7 @@ public struct OnboardingView<Header: View, Content: View, Footer: View>: View {
     private let footer: Footer
     
     @Environment(\.isInManagedNavigationStack) private var isInManagedNavigationStack
+    @Environment(\.isFirstInManagedNavigationStack) private var isFirstInManagedNavigationStack
     @Environment(\.onboardingViewEdgesWithPaddingDisabled) private var edgesWithPaddingDisabled
     
     public var body: some View {
@@ -100,6 +101,10 @@ public struct OnboardingView<Header: View, Content: View, Footer: View>: View {
             }
         }
         .padding(edgesWithImplicitPadding, 24)
+        // if this is the first view in a Stack, we need to add an implicit extra top padding,
+        // in order to compensate for the fact that the other steps in the stack will get some de-facto
+        // top padding via the navigation bar (which won't be present in the first step).
+        .padding(.top, isFirstInManagedNavigationStack ? 24 : 0)
     }
     
     /// The set of edges for which we want to apply implicit padding.


### PR DESCRIPTION
# padding adjustment

## :recycle: Current situation & Problem
This PR restores the pre-#69 behaviour of placing `OnboardingView`s into an `OnboardingStack`, where the first step would implicitly get some additional top padding in order to compensate for the missing navigation bar.

## :gear: Release Notes
n/a

## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
