### PR TITLE
fix consent dividers

### DIFF
--- a/Sources/SpeziConsent/Views/ConsentDocumentView.swift
+++ b/Sources/SpeziConsent/Views/ConsentDocumentView.swift
@@ -37,7 +37,7 @@ public struct ConsentDocumentView: View {
             dividerRule: .init { blockIdx, _ -> Bool in
                 let section = consentDocument.sections[blockIdx]
                 let nextSection = consentDocument.sections[blockIdx + 1]
-                return (section.isMarkdown && !nextSection.isMarkdown || !section.isMarkdown && nextSection.isMarkdown) && !nextSection.isSignature
+                return (section.isMarkdown && !nextSection.isMarkdown || !section.isMarkdown) && !nextSection.isSignature
             }
         ) { blockIdx, _ in
             let section = consentDocument.sections[blockIdx]


### PR DESCRIPTION
# fix consent dividers

## :recycle: Current situation & Problem
adjusts the `ConsentDocumentView`'s dividerRule to also place dividers between non-markdown sections


## :gear: Release Notes
- ConsentMarkdownView: place dividers between non-markdown sections


## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
