### PR TITLE
padding adjustments; expose OnboardingActionsView viewState

### DIFF
--- a/Sources/SpeziOnboarding/OnboardingActionsView.swift
+++ b/Sources/SpeziOnboarding/OnboardingActionsView.swift
@@ -33,101 +33,174 @@ import SwiftUI
 /// )
 /// ```
 public struct OnboardingActionsView: View {
-    private let primaryText: Text
-    private let primaryAction: @MainActor () async throws -> Void
-    private let secondaryText: Text?
-    private let secondaryAction: (@MainActor () async throws -> Void)?
+    private struct ButtonConfig {
+        let title: Text
+        let viewState: Binding<ViewState>?
+        let action: @MainActor () async throws -> Void
+    }
     
-    @State private var primaryActionState: ViewState = .idle
-    @State private var secondaryActionState: ViewState = .idle
+    private let primaryButton: ButtonConfig
+    private let secondaryButton: ButtonConfig?
+    
+    @State private var internalPrimaryViewState: ViewState = .idle
+    @State private var internalSecondaryViewState: ViewState = .idle
     
     
     @_documentation(visibility: internal) // swiftlint:disable:next attributes
     public var body: some View {
+        let primaryViewStateBinding = primaryButton.viewState ?? $internalPrimaryViewState
+        let secondaryViewStateBinding = secondaryButton?.viewState ?? $internalSecondaryViewState
         VStack(spacing: 0) {
-            AsyncButton(state: $primaryActionState, action: primaryAction) {
-                primaryText
+            AsyncButton(state: primaryViewStateBinding, action: primaryButton.action) {
+                primaryButton.title
                     .bold()
                     .frame(maxWidth: .infinity, minHeight: 38)
             }
             .buttonStyle(.borderedProminent)
             .applyGlassEffect(.regular, interactive: true)
-            if let secondaryText, let secondaryAction {
-                AsyncButton(state: $secondaryActionState, action: secondaryAction) {
-                    secondaryText
+            if let secondaryButton {
+                AsyncButton(state: secondaryViewStateBinding, action: secondaryButton.action) {
+                    secondaryButton.title
                 }
                 .padding(.vertical, 10)
             }
         }
-        .disabled(primaryActionState != .idle || secondaryActionState != .idle)
-        .viewStateAlert(state: $primaryActionState)
-        .viewStateAlert(state: $secondaryActionState)
+        .disabled(primaryViewStateBinding.wrappedValue != .idle || secondaryViewStateBinding.wrappedValue != .idle)
+        .viewStateAlert(state: primaryViewStateBinding)
+        .viewStateAlert(state: secondaryViewStateBinding)
     }
-
-
-    init(
-        primaryText: Text,
-        primaryAction: @escaping @MainActor () async throws -> Void,
-        secondaryText: Text? = nil,
-        secondaryAction: (@MainActor () async throws -> Void)? = nil
+    
+    private init(
+        primaryButton: ButtonConfig,
+        secondaryButton: ButtonConfig? = nil
     ) {
-        self.primaryText = primaryText
-        self.primaryAction = primaryAction
-        self.secondaryText = secondaryText
-        self.secondaryAction = secondaryAction
+        self.primaryButton = primaryButton
+        self.secondaryButton = secondaryButton
     }
+}
 
+
+extension OnboardingActionsView {
+    /// Creates an `OnboardingActionsView` instance that only contains a primary button.
+    /// - Parameters:
+    ///   - viewState: An optional `ViewState` binding.
+    ///   - text: The title of the primary button without localization.
+    ///   - action: The action that should be performed when pressing the primary button
+    public init(
+        viewState: Binding<ViewState>? = nil,
+        @ViewBuilder title: () -> Text,
+        action: @escaping @MainActor () async throws -> Void
+    ) {
+        self.init(
+            primaryButton: .init(title: title(), viewState: viewState, action: action)
+        )
+    }
+    
+    
+    /// Creates an `OnboardingActionsView` instance that contains a primary button and a secondary button.
+    /// - Parameters:
+    ///   - primaryViewState: An optional `ViewState` binding for controlling the primary action's state.
+    ///   - primaryText: The localized title of the primary button.
+    ///   - primaryAction: The action that should be performed when pressing the primary button
+    ///   - secondaryViewState: An optional `ViewState` binding for controlling the secondary action's state.
+    ///   - secondaryText: The localized title of the secondary button.
+    ///   - secondaryAction: The action that should be performed when pressing the secondary button
+    public init(
+        primaryViewState: Binding<ViewState>? = nil,
+        @ViewBuilder primaryTitle: () -> Text,
+        primaryAction: @escaping @MainActor () async throws -> Void,
+        secondaryViewState: Binding<ViewState>? = nil,
+        @ViewBuilder secondaryTitle: () -> Text,
+        secondaryAction: @escaping @MainActor () async throws -> Void
+    ) {
+        self.init(
+            primaryButton: .init(title: primaryTitle(), viewState: primaryViewState, action: primaryAction),
+            secondaryButton: .init(title: secondaryTitle(), viewState: secondaryViewState, action: secondaryAction)
+        )
+    }
+    
+    
     /// Creates an `OnboardingActionsView` instance that only contains a primary button.
     /// - Parameters:
     ///   - text: The title of the primary button without localization.
+    ///   - viewState: An optional `ViewState` binding.
     ///   - action: The action that should be performed when pressing the primary button
     @_disfavoredOverload
-    public init(_ text: some StringProtocol, action: @escaping @MainActor () async throws -> Void) {
-        self.init(primaryText: Text(text), primaryAction: action)
+    public init(
+        _ text: some StringProtocol,
+        viewState: Binding<ViewState>? = nil,
+        action: @escaping @MainActor () async throws -> Void
+    ) {
+        self.init(
+            primaryButton: .init(title: Text(text), viewState: viewState, action: action)
+        )
     }
     
     /// Creates an `OnboardingActionsView` instance that only contains a primary button.
     /// - Parameters:
     ///   - text: The localized title of the primary button.
+    ///   - viewState: An optional `ViewState` binding.
     ///   - action: The action that should be performed when pressing the primary button
-    public init(_ text: LocalizedStringResource, action: @escaping @MainActor () async throws -> Void) {
-        self.init(primaryText: Text(text), primaryAction: action)
+    public init(
+        _ text: LocalizedStringResource,
+        viewState: Binding<ViewState>? = nil,
+        action: @escaping @MainActor () async throws -> Void
+    ) {
+        self.init(
+            primaryButton: .init(title: Text(text), viewState: viewState, action: action)
+        )
     }
     
     /// Creates an `OnboardingActionsView` instance that contains a primary button and a secondary button.
     /// - Parameters:
     ///   - primaryText: The localized title of the primary button.
+    ///   - primaryViewState: An optional `ViewState` binding for controlling the primary action's state.
     ///   - primaryAction: The action that should be performed when pressing the primary button
     ///   - secondaryText: The localized title of the secondary button.
+    ///   - secondaryViewState: An optional `ViewState` binding for controlling the secondary action's state.
     ///   - secondaryAction: The action that should be performed when pressing the secondary button
     public init(
         primaryText: LocalizedStringResource,
+        primaryViewState: Binding<ViewState>? = nil, // swiftlint:disable:this function_default_parameter_at_end
         primaryAction: @escaping @MainActor () async throws -> Void,
         secondaryText: LocalizedStringResource,
+        secondaryViewState: Binding<ViewState>? = nil,
         secondaryAction: @escaping @MainActor () async throws -> Void
     ) {
-        self.init(primaryText: Text(primaryText), primaryAction: primaryAction, secondaryText: Text(secondaryText), secondaryAction: secondaryAction)
+        self.init(
+            primaryButton: .init(title: Text(primaryText), viewState: primaryViewState, action: primaryAction),
+            secondaryButton: .init(title: Text(secondaryText), viewState: secondaryViewState, action: secondaryAction)
+        )
     }
     
     /// Creates an `OnboardingActionsView` instance that contains a primary button and a secondary button.
     /// - Parameters:
     ///   - primaryText: The title of the primary button without localization.
+    ///   - primaryViewState: An optional `ViewState` binding for controlling the primary action's state.
     ///   - primaryAction: The action that should be performed when pressing the primary button
     ///   - secondaryText: The title of the secondary button without localization.
+    ///   - secondaryViewState: An optional `ViewState` binding for controlling the secondary action's state.
     ///   - secondaryAction: The action that should be performed when pressing the secondary button
     @_disfavoredOverload
     public init(
         primaryText: some StringProtocol,
+        primaryViewState: Binding<ViewState>? = nil, // swiftlint:disable:this function_default_parameter_at_end
         primaryAction: @escaping @MainActor () async throws -> Void,
         secondaryText: some StringProtocol,
+        secondaryViewState: Binding<ViewState>? = nil,
         secondaryAction: @escaping @MainActor () async throws -> Void
     ) {
         self.init(
-            primaryText: Text(primaryText),
-            primaryAction: primaryAction,
-            secondaryText: Text(secondaryText),
-            secondaryAction: secondaryAction
+            primaryButton: .init(title: Text(primaryText), viewState: primaryViewState, action: primaryAction),
+            secondaryButton: .init(title: Text(secondaryText), viewState: secondaryViewState, action: secondaryAction)
         )
+    }
+}
+
+
+extension View {
+    func transform(@ViewBuilder _ transform: @MainActor (Self) -> some View) -> some View {
+        transform(self)
     }
 }
 

--- a/Sources/SpeziOnboarding/OnboardingActionsView.swift
+++ b/Sources/SpeziOnboarding/OnboardingActionsView.swift
@@ -44,7 +44,7 @@ public struct OnboardingActionsView: View {
     
     @_documentation(visibility: internal) // swiftlint:disable:next attributes
     public var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             AsyncButton(state: $primaryActionState, action: primaryAction) {
                 primaryText
                     .bold()
@@ -56,7 +56,7 @@ public struct OnboardingActionsView: View {
                 AsyncButton(state: $secondaryActionState, action: secondaryAction) {
                     secondaryText
                 }
-                .padding(.top, 10)
+                .padding(.vertical, 10)
             }
         }
         .disabled(primaryActionState != .idle || secondaryActionState != .idle)

--- a/Sources/SpeziOnboarding/OnboardingTitleView.swift
+++ b/Sources/SpeziOnboarding/OnboardingTitleView.swift
@@ -15,25 +15,22 @@ import SwiftUI
 /// OnboardingTitleView(title: "Title", subtitle: "Subtitle")
 /// ```
 public struct OnboardingTitleView: View {
-    private static let isIOS26 = ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 26
-    
     private let title: Text
     private let subtitle: Text?
     
     @_documentation(visibility: internal) // swiftlint:disable:next attributes
     public var body: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: ProcessInfo.isIOS26 ? .leading : .center) {
             title
                 .bold()
                 .font(.largeTitle)
-                .multilineTextAlignment(Self.isIOS26 ? .leading : .center)
+                .multilineTextAlignment(ProcessInfo.isIOS26 ? .leading : .center)
                 .padding(.bottom)
                 .accessibilityAddTraits(.isHeader)
             
             if let subtitle {
                 subtitle
-                    .multilineTextAlignment(Self.isIOS26 ? .leading : .center)
-                    .padding(.bottom)
+                    .multilineTextAlignment(ProcessInfo.isIOS26 ? .leading : .center)
             }
         }
         .padding(.vertical)

--- a/Sources/SpeziOnboarding/OnboardingView.swift
+++ b/Sources/SpeziOnboarding/OnboardingView.swift
@@ -199,13 +199,13 @@ public struct OnboardingView<Header: View, Content: View, Footer: View>: View {
                     .padding(.bottom, footer is EmptyView ? bottomPadding : 0)
             }
             if !(footer is EmptyView) {
-                Spacer()
+                Spacer(minLength: 40)
                 footer
                     // if we do have a footer, we apply it here
                     .padding(.bottom, bottomPadding)
             }
         }
-        .padding(edgesWithImplicitPadding, 24)
+        .padding(edgesWithImplicitPadding)
         // if this is the first view in a Stack, we need to add an implicit extra top padding,
         // in order to compensate for the fact that the other steps in the stack will get some de-facto
         // top padding via the navigation bar (which won't be present in the first step).

--- a/Sources/SpeziOnboarding/SequentialOnboardingView.swift
+++ b/Sources/SpeziOnboarding/SequentialOnboardingView.swift
@@ -94,7 +94,9 @@ public struct SequentialOnboardingView<Header: View>: View {
                     }
                 }
             } footer: {
-                OnboardingActionsView(primaryText: actionButtonTitle) {
+                OnboardingActionsView {
+                    actionButtonTitle
+                } action: {
                     if currentStepIndex < steps.count - 1 {
                         currentStepIndex += 1
                         withAnimation {

--- a/Sources/SpeziOnboarding/SequentialOnboardingView.swift
+++ b/Sources/SpeziOnboarding/SequentialOnboardingView.swift
@@ -42,15 +42,15 @@ import SwiftUI
 public struct SequentialOnboardingView<Header: View>: View {
     /// A `Step` defines the way that information is displayed in an ``SequentialOnboardingView``.
     public struct Step {
-        /// The title of the area in the ``SequentialOnboardingView``.
-        public let title: Text?
-        /// The description of the area in the ``SequentialOnboardingView``.
-        public let description: Text
+        /// The step's title.
+        fileprivate let title: Text?
+        /// The step's description.
+        fileprivate let description: Text
         
-        /// Creates a new content for an area in the ``SequentialOnboardingView``.
+        /// Creates a sequential onboarding step.
         /// - Parameters:
-        ///   - title: The localized title of the area in the ``SequentialOnboardingView``.
-        ///   - description: The localized description of the area in the ``SequentialOnboardingView``.
+        ///   - title: The step's localized title.
+        ///   - description: The step's localized description.
         public init(
             title: LocalizedStringResource? = nil, // swiftlint:disable:this function_default_parameter_at_end
             description: LocalizedStringResource
@@ -59,10 +59,10 @@ public struct SequentialOnboardingView<Header: View>: View {
             self.description = Text(description)
         }
         
-        /// Creates a new content for an area in the ``SequentialOnboardingView``.
+        /// Creates a sequential onboarding step.
         /// - Parameters:
-        ///   - title: The title of the area in the ``SequentialOnboardingView`` without localization.
-        ///   - description: The description of the area in the ``SequentialOnboardingView`` without localization.
+        ///   - title: The step's title.
+        ///   - description: The step's description.
         @_disfavoredOverload
         public init(
             title: (some StringProtocol)? = String?.none, // swiftlint:disable:this function_default_parameter_at_end

--- a/Sources/SpeziOnboarding/Utils.swift
+++ b/Sources/SpeziOnboarding/Utils.swift
@@ -6,8 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-import SwiftUI
 import Foundation
+import SwiftUI
 
 
 enum _CompatGlassEffect { // swiftlint:disable:this type_name

--- a/Sources/SpeziOnboarding/Utils.swift
+++ b/Sources/SpeziOnboarding/Utils.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import Foundation
 
 
 enum _CompatGlassEffect { // swiftlint:disable:this type_name
@@ -29,4 +30,9 @@ extension View {
         self
         #endif
     }
+}
+
+
+extension ProcessInfo {
+    static let isIOS26 = ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 26
 }

--- a/Tests/UITests/TestApp/Views/ScreenshotsFlow.swift
+++ b/Tests/UITests/TestApp/Views/ScreenshotsFlow.swift
@@ -77,7 +77,7 @@ private struct InterestingModules: View {
             subtitle: "Here are a few key Spezi modules and features",
             steps: [
                 .init(title: "Onboarding", description: "The Onboarding module allows you to build an onboarding flow like this one."),
-                .init(title: "Account", description: "SpeziAccount enabled user log in and sign up, using Firebase and other services."),
+                .init(title: "Account", description: "SpeziAccount enables user log in and sign up, using Firebase and other services."),
                 .init(title: "HealthKit", description: "Work with Health data collected by the user's iPhone and Watch."),
                 .init(title: "Scheduler", description: "Via Spezi's Scheduler module, users can be prompted to complete tasks based on schedules.")
             ],

--- a/Tests/UITests/TestAppUITests/OnboardingTests.swift
+++ b/Tests/UITests/TestAppUITests/OnboardingTests.swift
@@ -173,7 +173,7 @@ final class OnboardingTests: XCTestCase {
         XCTAssert(app.staticTexts["Interesting Modules"].waitForExistence(timeout: 2))
         for (idx, step) in [
             "The Onboarding module allows you to",
-            "SpeziAccount enabled user log in and sign up",
+            "SpeziAccount enables user log in and sign up",
             "Work with Health data collected by",
             "Via Spezi's Scheduler module, users can be prompted"
         ].enumerated() {


### PR DESCRIPTION
# padding adjustments; expose OnboardingActionsView viewState

## :recycle: Current situation & Problem
this PR:
- makes some padding adjustments, reducing the amount of space by which eg the OnboardingView insets its content from the screen edged
- extends the `OnboardingActionsView` to allow supplying external `ViewState` bindings


## :gear: Release Notes
*todo*


## :books: Documentation
is updated


## :white_check_mark: Testing
not yet


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
