### PR TITLE
iOS 26: properly left-align onboarding titles

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ jobs:
         config: [Debug, Release]
         platform:
           - name: iOS
-            destination: 'platform=iOS Simulator,name=iPhone 16 Pro'
+            destination: 'platform=iOS Simulator,name=iPhone 17 Pro'
           - name: macOS
             destination: 'platform=macOS,name=My Mac'
           - name: visionOS
@@ -48,7 +48,7 @@ jobs:
         config: [Debug, Release]
         platform:
           - name: iOS
-            destination: 'platform=iOS Simulator,name=iPhone 16 Pro'
+            destination: 'platform=iOS Simulator,name=iPhone 17 Pro'
           - name: iPadOS
             destination: 'platform=iOS Simulator,name=iPad Air 13-inch (M3)'
           - name: visionOS

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -215,7 +215,7 @@ only_rules:
   # Operators should be surrounded by a single whitespace when they are being used.
   - operator_usage_whitespace
   # Operators should be surrounded by a single whitespace when defining them.
-  - operator_whitespace
+  - function_name_whitespace
   # Matching an enum case against an optional enum without ‘?’ is supported on Swift 5.1 and above.
   - optional_enum_case_matching
   # A doc comment should be attached to a declaration.
@@ -257,7 +257,7 @@ only_rules:
   # Objective-C attribute (@objc) is redundant in declaration.
   - redundant_objc_attribute
   # Initializing an optional variable with nil is redundant.
-  - redundant_optional_initialization
+  - implicit_optional_initialization
   # Property setter access level shouldn't be explicit if it's the same as the variable access level.
   - redundant_set_access_control
   # String enum values can be omitted when they are equal to the enumcase name.

--- a/Sources/SpeziOnboarding/OnboardingTitleView.swift
+++ b/Sources/SpeziOnboarding/OnboardingTitleView.swift
@@ -20,31 +20,20 @@ public struct OnboardingTitleView: View {
     
     @_documentation(visibility: internal) // swiftlint:disable:next attributes
     public var body: some View {
-        if ProcessInfo.isIOS26 {
-            HStack {
-                mainContent
-                Spacer()
-            }
-        } else {
-            mainContent
-        }
-    }
-    
-    private var mainContent: some View {
         VStack(alignment: ProcessInfo.isIOS26 ? .leading : .center) {
             title
                 .bold()
                 .font(.largeTitle)
-                .multilineTextAlignment(ProcessInfo.isIOS26 ? .leading : .center)
                 .padding(.bottom)
                 .accessibilityAddTraits(.isHeader)
             
             if let subtitle {
                 subtitle
-                    .multilineTextAlignment(ProcessInfo.isIOS26 ? .leading : .center)
             }
         }
         .padding(.vertical)
+        .frame(maxWidth: .infinity, alignment: ProcessInfo.isIOS26 ? .leading : .center)
+        .multilineTextAlignment(ProcessInfo.isIOS26 ? .leading : .center)
     }
     
     /// Creates an `OnboardingTitleView` instance that contains a title and an optional subtitle.

--- a/Sources/SpeziOnboarding/OnboardingTitleView.swift
+++ b/Sources/SpeziOnboarding/OnboardingTitleView.swift
@@ -20,6 +20,17 @@ public struct OnboardingTitleView: View {
     
     @_documentation(visibility: internal) // swiftlint:disable:next attributes
     public var body: some View {
+        if ProcessInfo.isIOS26 {
+            HStack {
+                mainContent
+                Spacer()
+            }
+        } else {
+            mainContent
+        }
+    }
+    
+    private var mainContent: some View {
         VStack(alignment: ProcessInfo.isIOS26 ? .leading : .center) {
             title
                 .bold()

--- a/Tests/UITests/TestApp/Views/OnboardingWelcomeTestView.swift
+++ b/Tests/UITests/TestApp/Views/OnboardingWelcomeTestView.swift
@@ -6,12 +6,13 @@
 // SPDX-License-Identifier: MIT
 //
 
+// swiftlint:disable accessibility_label_for_image
+
 import SpeziOnboarding
 import SpeziViews
 import SwiftUI
 
 
-// swiftlint:disable accessibility_label_for_image
 struct OnboardingWelcomeTestView: View {
     @Environment(ManagedNavigationStack.Path.self) private var path
     


### PR DESCRIPTION
# iOS 26: properly left-align onboarding titles

## :recycle: Current situation & Problem
issue: we previously had left-aligned the text, but since the title was placed in a VStack, it'd still get centered overall.

this PR instead places the title in a left-aligned frame if running on iOS 26+


## :gear: Release Notes
- properly left-align onboarding titles on iOS 26+


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
